### PR TITLE
Add Mini Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A list of awesome online tools
 
+- [Mini Tools](https://mini-tools.uk) - Self-recommendation: free multilingual online tools, including a UK tax calculator, VAT calculator, mortgage calculator, free image hosting with Markdown links, PDF tools, and developer utilities.
+
 
 - [PicDiet](https://www.picdiet.com) - Unique & Powerful JavaScript algorithm to reduce image size by up to 80% without compromising quality
 - [KouTu](https://www.gaoding.com/koutu/) - 画几笔，3秒稿定透明背景


### PR DESCRIPTION
Hi, self-recommending a small free online tools site I maintain: https://mini-tools.uk\n\nIt may fit this list because it collects practical browser tools in one place: UK tax calculator, take-home pay calculator, VAT calculator, mortgage calculator, free image hosting with Markdown image links, PDF tools, and developer utilities.\n\nI added one concise entry and kept the existing README style.